### PR TITLE
style: clean line endings a bit

### DIFF
--- a/lessons/exercise-0-hjkl-x.md
+++ b/lessons/exercise-0-hjkl-x.md
@@ -21,27 +21,27 @@ To use the exercises, please curl the file to your machine and edit it with vim.
 ### press l and j to follow the line and x to delete the o
 -+
  |
- |                          
+ |
  +------+
         |
-        |                          
+        |
         +------+
                |
-               |                          
+               |
                +------o
 
 ### press l and j and h to follow the line and x to delete the o
 -+
  |
- |                          
+ |
  +------+
         |
-        |                          
+        |
  +------+
  |
  +------+
         |
-        |                          
+        |
  o------+
 
 ### press l, j, h, and k to follow the line and x to delete the o
@@ -51,7 +51,7 @@ To use the exercises, please curl the file to your machine and edit it with vim.
  +------+      |      |      +------+
                |      |
         +------+      |
-        |             |  
+        |             |
         |             |
         |             |
         +-------------+


### PR DESCRIPTION
Just removed some spaces at the end of lines,
so that they don't highlight with `set list, set listchars=...` options like here:

<img width="791" alt="Screenshot 2024-07-09 at 19 51 47" src="https://github.com/ThePrimeagen/vim-fundamentals/assets/5403694/a969d55c-2ce2-4abe-889c-89b673840310">
